### PR TITLE
fix verify_embed without text

### DIFF
--- a/discord/ext/test/runner.py
+++ b/discord/ext/test/runner.py
@@ -145,7 +145,7 @@ def verify_embed(embed=None, allow_text=False, equals=True, peek=False,assert_no
     try:
         message = sent_queue.get_nowait()
         if not allow_text:
-            assert message.content is None
+            assert not message.content
         if peek:
             messages = [message]
             while not sent_queue.empty():


### PR DESCRIPTION
I had some troubles when comparing "Expected Embed" with "Dpytest reveiced Embed" when the message only has embed (no text) with `verify_embed()`

Because in this case, `content` is `''`, and `assert None` was messy.

I think this is better this way. (and it works)