### PR TITLE
add members intent so it pass all pytest tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,9 @@ def client(event_loop):
 
 @pytest.fixture
 def bot(request, event_loop):
-    b = commands.Bot("!", loop=event_loop)
+    intents = discord.Intents.default()
+    intents.members = True
+    b = commands.Bot("!", loop=event_loop, intents=intents)
 
     marks = request.function.pytestmark
     mark = None


### PR DESCRIPTION
I added the "members intent", so the tests don't fail (there was a problem, where fake guilds didn't have members, and all tests failed).

Now, it passes all tests, on a local machine (with discord.py 1.5)

So it should pass Travis CI as well.