### PR TITLE
chunk_guild in FakeState.

### DIFF
--- a/discord/ext/test/state.py
+++ b/discord/ext/test/state.py
@@ -42,4 +42,7 @@ class FakeState(dstate.ConnectionState):
         guild : discord.Guild = discord.utils.get(self.guilds, id=guild.id)
         return guild.members
 
+    async def chunk_guild(self, *args, **kwargs):
+        pass
+
 


### PR DESCRIPTION
Fix messages like this when executing pytest :
```console
"Task was destroyed but it is pending!
task: <Task pending coro=<ConnectionState.chunk_guild()" messages
```