### PR TITLE
discord.py 1.7.1 support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=3
 pytest
-discord.py==1.6.0
+discord.py==1.7.1

--- a/discord/ext/test/backend.py
+++ b/discord/ext/test/backend.py
@@ -136,7 +136,7 @@ class FakeHttp(dhttp.HTTPClient):
             perm = channel.permissions_for(channel.guild.get_member(user.id))
         else:
             perm = channel.permissions_for(user)
-        if not ((perm.send_messages and perm.read_messages) or perm.administrator):
+        if not (perm.send_messages or perm.administrator):
             raise discord.errors.Forbidden(FakeRequest(403, "missing send_messages"), "send_messages")
 
         message = make_message(

--- a/discord/ext/test/factories.py
+++ b/discord/ext/test/factories.py
@@ -168,7 +168,9 @@ def dict_from_overwrite(target, overwrite):
     ovr = {
         'id': target.id,
         'allow': allow.value,
-        'deny': deny.value
+        'deny': deny.value,
+        'allow_new': allow.value,
+        'deny_new': deny.value
     }
     if isinstance(target, discord.Role):
         ovr['type'] = 'role'


### PR DESCRIPTION
Add allow & deny_new, and removed check for read_messages (no longer part of text default perms)